### PR TITLE
use multi json instead of json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,14 @@
 source 'https://rubygems.org'
 
 gem 'sinatra', '1.4.6'
-
 gem 'bson', '4.0.0'
-gem 'json', '1.8.3'
+gem 'multi_json', '~> 1.11'
+gem 'jrjackson', '~> 0.3.8', platforms: :jruby
+gem 'oj', '~> 2.14', platforms: :ruby
 gem 'rdf', '1.99.1'
 gem 'rdf-vocab', '~> 0.8.7'
 gem 'sparql-client', '1.99.0', require: 'sparql/client'
+gem 'rake'
 
 Dir.glob(File.join(File.dirname(__FILE__), 'ext', '**', "Gemfile")) do |gemfile|
     eval(IO.read(gemfile), binding)

--- a/web.rb
+++ b/web.rb
@@ -1,7 +1,7 @@
 require 'sinatra'
 require 'logger'
 require 'sparql/client'
-require 'json'
+require 'multi_json'
 require 'rdf/vocab'
 require 'bson'
 
@@ -54,7 +54,7 @@ helpers do
 
   def error(title, status = 400)
     log.error "HTTP status #{status}: #{title}"
-    halt status, { errors: [{ title: title }] }.to_json
+    halt status, MultiJson.dump({ errors: [{ title: title }] })
   end
 
   def validate_json_api_content_type(request)


### PR DESCRIPTION
it seems weblogic (though not tomcat,jetty, etc) has some issues with the json(-java) gem. The only working workaround we found is using jrjackson for jruby and another (Currently oj) for pure ruby platform. The multi_json gem wraps around multiple json parsers and uses what is available.