### PR TITLE
provide standardized framework for api tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'sparql-client', '1.99.0', require: 'sparql/client'
 
 group :test, :development do
 	gem 'rspec', '~> 3.4'
+	gem 'json_spec', '~> 1.1', '>= 1.1.4'
+	gem 'rack-test', '~> 0.6.3'
 end
 
 Dir.glob(File.join(File.dirname(__FILE__), 'ext', '**', "Gemfile")) do |gemfile|


### PR DESCRIPTION
suggest to use json_spec (a rspec extension) to make writing api tests as straightforward as possible.
By adding it to the template we standardize the test framework for all microservices