### PR TITLE
escape sparql strings using triple quotes

### DIFF
--- a/lib/escape_helpers.rb
+++ b/lib/escape_helpers.rb
@@ -2,7 +2,7 @@ require 'uri'
 
 class String
   def sparql_escape
-    '"' + self.gsub(/[\\"']/) { |s| '\\' + s } + '"'
+    '"""' + self.gsub(/[\\"]/) { |s| '\\' + s } + '"""'
   end
 end
 


### PR DESCRIPTION
In order to allow newline characters and similar.